### PR TITLE
Fix GitHub Actions CI execution on all matrix OSes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,30 +12,45 @@ jobs:
                 os: [ubuntu-latest, macos-latest, windows-latest]
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 fetch-depth: 10
                 persist-credentials: false
 
             - name: Set up Python
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v5
               with:
                 python-version: "3.10"
 
-            - name: Install calibre dependencies
-              run:
-                  python setup/unix-ci.py install
+            - name: Install calibre dependencies (Linux/macOS)
+              if: runner.os != 'Windows'
+              run: python setup/unix-ci.py install
 
-            - name: Bootstrap calibre
-              run:
-                  python setup/unix-ci.py bootstrap
+            - name: Bootstrap calibre (Linux/macOS)
+              if: runner.os != 'Windows'
+              run: python setup/unix-ci.py bootstrap
 
-            - name: Test calibre
+            - name: Test calibre (Linux/macOS)
+              if: runner.os != 'Windows'
               env:
                 PYTHONWARNINGS: error
                 CALIBRE_SHOW_DEPRECATION_WARNINGS: 1
-              run:
-                  python setup/unix-ci.py test
+              run: python setup/unix-ci.py test
+
+            - name: Install calibre dependencies (Windows)
+              if: runner.os == 'Windows'
+              run: python setup/win-ci.py install
+
+            - name: Bootstrap calibre (Windows)
+              if: runner.os == 'Windows'
+              run: python setup/win-ci.py bootstrap
+
+            - name: Test calibre (Windows)
+              if: runner.os == 'Windows'
+              env:
+                PYTHONWARNINGS: error
+                CALIBRE_SHOW_DEPRECATION_WARNINGS: 1
+              run: python setup/win-ci.py test
 
     archtest:
         name: Test on Arch
@@ -51,7 +66,7 @@ jobs:
                 pacman -S --noconfirm tar
 
             - name: Checkout source code
-              uses: actions/checkout@master
+              uses: actions/checkout@v4
               with:
                 fetch-depth: 10
 


### PR DESCRIPTION
### Motivation

- The existing workflow used `setup/unix-ci.py` for every matrix OS and older action versions, which can break CI on Windows and relies on outdated Action releases.

### Description

- Bumped `actions/checkout` to `@v4` and `actions/setup-python` to `@v5` in `/.github/workflows/ci.yml` to use current Action versions.
- Split the `test` job steps by runner OS using `if: runner.os != 'Windows'` and `if: runner.os == 'Windows'` so Linux/macOS run `setup/unix-ci.py` and Windows runs `setup/win-ci.py` for install/bootstrap/test.
- Updated the Arch container job to use `actions/checkout@v4` and kept the existing Arch bootstrap/test commands.

### Testing

- Validated the modified workflow YAML with Ruby using `YAML.load_file('.github/workflows/ci.yml')`, which succeeded.
- Attempted to parse the workflow with Python `yaml.safe_load`, which failed due to missing `PyYAML` (`ModuleNotFoundError`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5483ebc9c833199763d4a84aec0bf)